### PR TITLE
Render from file and generate images if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+sphinxcontrib/version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,3 @@ python:
 - '2.7'
 install: pip install -q -r requirements.txt
 script: cd example && make clean && make html && cd ..
-notifications:
-  email:
-    on_success: never
-    on_failure: always
-deploy:
-  - provider: pypi
-    distributions: sdist
-    server: https://test.pypi.org/legacy/
-    user: bavo.van.achte
-    password:
-      secure: eTU2xAyjwVyYrpX8A4H64a6NNrDdVw4p45h0ZWzxD0Fb+4MQ6P/S6td/vn7tZGoBIbWVwzsOAaKNQLs+V2D03jtehxf12pkTw7I21B/hDgsp2DuTFM2GI/xOCcA7VoBEuEBZiMJiUGFbg7hoa/cHqHd3s97IowZ2+WaIzZoL28D0sSknyRTva63sG/oQfMWXCZ5SH4DthoFCsB3+jXhC4HKZbJzYOw2xeHHemkKmXo65a/whwsya++UuCqpo+/n+jWycjFun00sy2nE1CecQ4l0F4EpWPZgSR/a3mu4qVFW5YuZ9N1scorzZwryCREGwWRmNRRMtqNnfBcyrYvoDIRWcC1vkqv5511Qdu6ZlnHeh5FPNDMJefzzaOokpGlCLmTWcwjCprUyjXPW9xyHoHU/kdDiw5TUMmtkDvK/EgVoUNbNsCkmywbPaWzDimF3ghC0BbV2vfMCWUlBeO+C5/4HIRKJ5VKcTW9FfbuQe61tf1mN9af8j1VGXZSB6Y/aPSGQkrt0Aq+LbzMAn4Hf9z42/UGVS2/lHb7X0/p2dVEl3RG4mr8l/DtpZ5ilzF4EmFx2By+1eN24CYDshrc7momuZ+8JFUf/ECuMCi9Dv7L0UpwbQyYyoJmjyBAcCAXyZ2Db5sPuFuTm4mBeIbPe3RWmMApD8bdPq503K8g/siN4=
-    on:
-      branch: master
-      tags: false
-  - provider: pypi
-    distributions: sdist
-    user: bavo.van.achte
-    password:
-      secure: eTU2xAyjwVyYrpX8A4H64a6NNrDdVw4p45h0ZWzxD0Fb+4MQ6P/S6td/vn7tZGoBIbWVwzsOAaKNQLs+V2D03jtehxf12pkTw7I21B/hDgsp2DuTFM2GI/xOCcA7VoBEuEBZiMJiUGFbg7hoa/cHqHd3s97IowZ2+WaIzZoL28D0sSknyRTva63sG/oQfMWXCZ5SH4DthoFCsB3+jXhC4HKZbJzYOw2xeHHemkKmXo65a/whwsya++UuCqpo+/n+jWycjFun00sy2nE1CecQ4l0F4EpWPZgSR/a3mu4qVFW5YuZ9N1scorzZwryCREGwWRmNRRMtqNnfBcyrYvoDIRWcC1vkqv5511Qdu6ZlnHeh5FPNDMJefzzaOokpGlCLmTWcwjCprUyjXPW9xyHoHU/kdDiw5TUMmtkDvK/EgVoUNbNsCkmywbPaWzDimF3ghC0BbV2vfMCWUlBeO+C5/4HIRKJ5VKcTW9FfbuQe61tf1mN9af8j1VGXZSB6Y/aPSGQkrt0Aq+LbzMAn4Hf9z42/UGVS2/lHb7X0/p2dVEl3RG4mr8l/DtpZ5ilzF4EmFx2By+1eN24CYDshrc7momuZ+8JFUf/ECuMCi9Dv7L0UpwbQyYyoJmjyBAcCAXyZ2Db5sPuFuTm4mBeIbPe3RWmMApD8bdPq503K8g/siN4=
-    on:
-      branch: master
-      tags: true
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 
 install:
   - pip install ..
+  - pip install sphinx_rtd_theme
 
 script:
   - make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 python:
 - '2.7'
+- "3.3"
+- "3.4"
+- "3.5"
+- "3.6"
 install: pip install -q -r requirements.txt
 script: cd example && make clean && make html && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,32 @@
 language: python
 
+addons:
+  apt:
+    packages:
+    - latexmk
+    - texlive-latex-recommended
+    - texlive-fonts-recommended
+    - texlive-latex-extra
+
 python:
-- '2.7'
-- "3.3"
-- "3.4"
-- "3.5"
-- "3.6"
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 
 before_install:
   - cd example
 
 install:
+  - pip install --upgrade pip
   - pip install ..
   - pip install sphinx_rtd_theme
 
 script:
-  - make html
+  - make clean html
+  - make clean singlehtml
+  - make clean dirhtml
+  - make clean html WAVEDROM_HTML_NOJSINLINE=1
+  - make clean singlehtml WAVEDROM_HTML_NOJSINLINE=1
+  - make clean dirhtml WAVEDROM_HTML_NOJSINLINE=1
+  - if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then make clean latexpdf; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: python
+
 python:
 - '2.7'
 - "3.3"
 - "3.4"
 - "3.5"
 - "3.6"
-install: pip install -q -r requirements.txt
-script: cd example && make clean && make html && cd ..
+
+before_install:
+  - cd example
+
+install:
+  - pip install ..
+
+script:
+  - make html

--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,10 @@ A sphinx extension that allows including wavedrom diagrams by using its text-bas
 Wavedrom online editor and tutorial: http://wavedrom.com/
 
 .. image:: https://travis-ci.org/bavovanachte/sphinx-wavedrom.svg?branch=master
-    :target: https://travis-ci.org/bavovanachte/sphinx-wavedrom
+	:target: https://travis-ci.org/bavovanachte/sphinx-wavedrom
 
 .. image:: https://badge.fury.io/py/sphinxcontrib-wavedrom.svg
-    :target: https://badge.fury.io/py/sphinxcontrib-wavedrom
+	:target: https://badge.fury.io/py/sphinxcontrib-wavedrom
 
 Installation
 ------------
@@ -17,7 +17,7 @@ Installation
 The wavedrom extension can be installed using pip:
 
 ::
-	
+
 	pip install sphinxcontrib-wavedrom
 
 and by adding **'sphinxcontrib.wavedrom'** to the extensions list in your conf.py file.
@@ -31,20 +31,65 @@ The extension is useable in the form of an extra wavedrom directive, as shown be
 
 	.. wavedrom::
 
-		{ signal: [
-		  	{ name: "clk",  wave: "P......" },
-		  	{ name: "bus",  wave: "x.==.=x", data: ["head", "body", "tail", "data"] },
-		  	{ name: "wire", wave: "0.1..0." }
+		{ "signal": [
+		  	{ "name": "clk",  "wave": "P......" },
+		  	{ "name": "bus",  "wave": "x.==.=x", "data": ["head", "body", "tail", "data"] },
+		  	{ "name": "wire", "wave": "0.1..0." }
 		]}
 
-The extension will not generate an image out of the diagram description itself,
-but it will surround it with some html and js tags in the final html document
-that allow the images to be rendered by the browser.
+Alternatively, it can read the json from a file:
+
+::
+
+	.. wavedrom:: mywave.json
+
+When configured to generate images (see `Configuration`_) the directive will generate an image and include
+it into the input. It allows for the same configuration as the image directive:
+
+::
+
+	.. wavedrom:: mywave.json
+        :height: 100px
+        :width: 200 px
+        :scale: 50 %
+        :alt: alternate text
+        :align: right
+
+The image can be turned into a figure by adding a caption:
+
+::
+
+    .. wavedrom:: mywave.json
+        :caption: My wave figure
+
+The extension can be configured (see `Configuration`_) to not generate an image out of the diagram description
+itself, but to surround it with some html and js tags in the final html document that allow the images to be rendered
+by the browser. This is the currently the default for HTML output.
 
 Configuration
 -------------
 
-The extension can work in 2 modes:
+The extension can be configured to either directly output images or by emitting the javascript to live-render the
+wavedrom code, which obviously only works for HTML output. All other outputs (most notably ``latexpdf``) embed a
+generated image in any case, but this is only supported when using Python 3.
+
+For HTML output the configuration item ``wavedrom_html_jsinline`` (default: ``True``) can toggled to generate images
+instead of inline javascript code. You must add the following line to your ``conf.py``:
+
+::
+
+    wavedrom_html_jsinline = False
+
+or overwrite the setting on the command line, for example:
+
+::
+
+    sphinx-build -b html -D wavedrom_html_jsinline=0 sources build/html
+
+HTML: Inline Javascript
+```````````````````````
+
+When HTML building is configured to inline the javascript (default), the extension can work in 2 modes:
 
 - Online mode: 	the extension links to the javascript file(s) provided by the wavedrom server
 - Offline mode: the extension uses the javascript file(s) that are saved locally on your drive.
@@ -57,6 +102,7 @@ If offline mode is desired, the following parameters need to be provided:
 - **offline_wavedrom_js_path** : the path to the wavedrom javascript file (the url to the online version is "http://wavedrom.com/WaveDrom.js")
 
 The paths given for these configurations need to be relative to the configuration directory (the directory that contains conf.py)
+
 
 Examples
 --------

--- a/example/Makefile
+++ b/example/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build

--- a/example/Makefile
+++ b/example/Makefile
@@ -7,6 +7,10 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
 
+ifdef WAVEDROM_HTML_NOJSINLINE
+SPHINXOPTS += -D wavedrom_html_jsinline=0
+endif
+
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
 $(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)

--- a/example/source/conf.py
+++ b/example/source/conf.py
@@ -22,11 +22,11 @@ import sphinx_rtd_theme
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinxcontrib.wavedrom']
+extensions = ['sphinxcontrib.wavedrom', 'sphinx.ext.ifconfig']
 
-#offline_skin_js_path = r"default.js"
 offline_skin_js_path = r"default.js"
 offline_wavedrom_js_path = r"../wavedrom.js"
+#wavedrom_html_jsinline = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/example/source/conf.py
+++ b/example/source/conf.py
@@ -13,25 +13,16 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 import sphinx_rtd_theme
-import sys
-import os
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
-sys.path.insert(0, os.path.abspath('../../sphinxcontrib'))
-
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['wavedrom']
+extensions = ['sphinxcontrib.wavedrom']
 
 #offline_skin_js_path = r"default.js"
 offline_skin_js_path = r"default.js"

--- a/example/source/example.json
+++ b/example/source/example.json
@@ -1,0 +1,10 @@
+{ "signal": [
+    { "name": "A", "wave": "01..0..",  "node": ".a..e.." },
+    { "name": "B", "wave": "0.1..0.",  "node": "..b..d.", "phase":0.5 },
+    { "name": "C", "wave": "0..1..0",  "node": "...c..f" },
+    {                              "node": "...g..h" }
+],
+"edge": [
+    "b-|a t1", "a-|c t2", "b-|-c t3", "c-|->e t4", "e-|>f more text",
+    "e|->d t6", "c-g", "f-h", "g<->h 3 ms"
+]}

--- a/example/source/index.rst
+++ b/example/source/index.rst
@@ -274,3 +274,9 @@ Step 9. Some code
 			{name: 'bin', wave: '='.repeat(ticks), data: data}, arr
 		]};
 	})(5, 16)
+
+=================
+Step10. From file
+=================
+
+.. wavedrom:: example.json

--- a/example/source/index.rst
+++ b/example/source/index.rst
@@ -29,7 +29,7 @@ Step 1. The Signal
 
 .. wavedrom::
 
-	{ signal: [{ name: "Alfa", wave: "01.zx=ud.23.45" }] }
+	{ "signal": [{ "name": "Alfa", "wave": "01.zx=ud.23.45" }] }
 
 ====================
 Step 2. Adding Clock
@@ -37,17 +37,17 @@ Step 2. Adding Clock
 
 .. wavedrom::
 
-	{ signal: [
-	  	{ name: "pclk", wave: 'p.......' },
-	  	{ name: "Pclk", wave: 'P.......' },
-	  	{ name: "nclk", wave: 'n.......' },
-	  	{ name: "Nclk", wave: 'N.......' },
+	{ "signal": [
+	  	{ "name": "pclk", "wave": "p......." },
+	  	{ "name": "Pclk", "wave": "P......." },
+	  	{ "name": "nclk", "wave": "n......." },
+	  	{ "name": "Nclk", "wave": "N......." },
 	  	{},
-	  	{ name: 'clk0', wave: 'phnlPHNL' },
-	  	{ name: 'clk1', wave: 'xhlhLHl.' },
-	  	{ name: 'clk2', wave: 'hpHplnLn' },
-	  	{ name: 'clk3', wave: 'nhNhplPl' },
-	  	{ name: 'clk4', wave: 'xlh.L.Hx' },
+	  	{ "name": "clk0", "wave": "phnlPHNL" },
+	  	{ "name": "clk1", "wave": "xhlhLHl." },
+	  	{ "name": "clk2", "wave": "hpHplnLn" },
+	  	{ "name": "clk3", "wave": "nhNhplPl" },
+	  	{ "name": "clk4", "wave": "xlh.L.Hx" }
 	]}
 
 ============================
@@ -56,10 +56,10 @@ Step 3. Putting all together
 
 .. wavedrom::
 
-	{ signal: [
-	  	{ name: "clk",  wave: "P......" },
-	  	{ name: "bus",  wave: "x.==.=x", data: ["head", "body", "tail", "data"] },
-	  	{ name: "wire", wave: "0.1..0." }
+	{ "signal": [
+	  	{ "name": "clk",  "wave": "P......" },
+	  	{ "name": "bus",  "wave": "x.==.=x", "data": ["head", "body", "tail", "data"] },
+	  	{ "name": "wire", "wave": "0.1..0." }
 	]}
 
 ========================
@@ -68,12 +68,12 @@ Step 4. Spacers and Gaps
 
 .. wavedrom::
 
-	{ signal: [
-	  	{ name: "clk",         wave: "p.....|..." },
-	  	{ name: "Data",        wave: "x.345x|=.x", data: ["head", "body", "tail", "data"] },
-	  	{ name: "Request",     wave: "0.1..0|1.0" },
+	{ "signal": [
+	  	{ "name": "clk",         "wave": "p.....|..." },
+	  	{ "name": "Data",        "wave": "x.345x|=.x", "data": ["head", "body", "tail", "data"] },
+	  	{ "name": "Request",     "wave": "0.1..0|1.0" },
 	  	{},
-	  	{ name: "Acknowledge", wave: "1.....|01." }
+	  	{ "name": "Acknowledge", "wave": "1.....|01." }
 	]}
 
 ==================
@@ -82,22 +82,22 @@ Step 5. The groups
 
 .. wavedrom::
 
-	{ signal: [
-	  	{    name: 'clk',   wave: 'p..Pp..P'},
-	  	['Master',
-	  	  	['ctrl',
-	  	  	  	{name: 'write', wave: '01.0....'},
-	  	  	  	{name: 'read',  wave: '0...1..0'}
+	{ "signal": [
+	  	{    "name": "clk",   "wave": "p..Pp..P"},
+	  	["Master",
+	  	  	["ctrl",
+	  	  	  	{"name": "write", "wave": "01.0...."},
+	  	  	  	{"name": "read",  "wave": "0...1..0"}
 	  	  	],
-	  	  	{  name: 'addr',  wave: 'x3.x4..x', data: 'A1 A2'},
-	  	  	{  name: 'wdata', wave: 'x3.x....', data: 'D1'   },
+	  	  	{  "name": "addr",  "wave": "x3.x4..x", "data": "A1 A2"},
+	  	  	{  "name": "wdata", "wave": "x3.x....", "data": "D1"   }
 	  	],
 	  	{},
-	  	['Slave',
-	  	  	['ctrl',
-	  	  	  	{name: 'ack',   wave: 'x01x0.1x'},
+	  	["Slave",
+	  	  	["ctrl",
+	  	  	  	{"name": "ack",   "wave": "x01x0.1x"}
 	  	  	],
-	  	  	{  name: 'rdata', wave: 'x.....4x', data: 'Q2'},
+	  	  	{  "name": "rdata", "wave": "x.....4x", "data": "Q2"}
 	  	]
 	]}
 
@@ -107,12 +107,12 @@ Step 6. Period and Phase
 
 .. wavedrom::
 
-	{ signal: [
-	  	{ name: "CK",   wave: "P.......",                                              period: 2  },
-	  	{ name: "CMD",  wave: "x.3x=x4x=x=x=x=x", data: "RAS NOP CAS NOP NOP NOP NOP", phase: 0.5 },
-	  	{ name: "ADDR", wave: "x.=x..=x........", data: "ROW COL",                     phase: 0.5 },
-	  	{ name: "DQS",  wave: "z.......0.1010z." },
-	  	{ name: "DQ",   wave: "z.........5555z.", data: "D0 D1 D2 D3" }
+	{ "signal": [
+	  	{ "name": "CK",   "wave": "P.......",                                              "period": 2  },
+	  	{ "name": "CMD",  "wave": "x.3x=x4x=x=x=x=x", "data": "RAS NOP CAS NOP NOP NOP NOP", "phase": 0.5 },
+	  	{ "name": "ADDR", "wave": "x.=x..=x........", "data": "ROW COL",                     "phase": 0.5 },
+	  	{ "name": "DQS",  "wave": "z.......0.1010z." },
+	  	{ "name": "DQ",   "wave": "z.........5555z.", "data": "D0 D1 D2 D3" }
 	]}
 
 ============================
@@ -124,12 +124,12 @@ Hscale=1
 
 .. wavedrom::
 
-	{ signal: [
-	  	{ name: "clk",     wave: "p...." },
-	  	{ name: "Data",    wave: "x345x",  data: ["head", "body", "tail"] },
-	  	{ name: "Request", wave: "01..0" }
+	{ "signal": [
+	  	{ "name": "clk",     "wave": "p...." },
+	  	{ "name": "Data",    "wave": "x345x",  "data": ["head", "body", "tail"] },
+	  	{ "name": "Request", "wave": "01..0" }
 	  	],
-	  	config: { hscale: 1 }
+	  	"config": { "hscale": 1 }
 	}
 
 Hscale=2
@@ -137,12 +137,12 @@ Hscale=2
 
 .. wavedrom::
 
-	{ signal: [
-	  	{ name: "clk",     wave: "p...." },
-	  	{ name: "Data",    wave: "x345x",  data: ["head", "body", "tail"] },
-	  	{ name: "Request", wave: "01..0" }
+	{ "signal": [
+	  	{ "name": "clk",     "wave": "p...." },
+	  	{ "name": "Data",    "wave": "x345x",  "data": ["head", "body", "tail"] },
+	  	{ "name": "Request", "wave": "01..0" }
 	  	],
-	  	config: { hscale: 2 }
+	  	"config": { "hscale": 2 }
 	}
 
 Hscale=3
@@ -150,12 +150,12 @@ Hscale=3
 
 .. wavedrom::
 
-	{ signal: [
-	  	{ name: "clk",     wave: "p...." },
-	  	{ name: "Data",    wave: "x345x",  data: ["head", "body", "tail"] },
-	  	{ name: "Request", wave: "01..0" }
+	{ "signal": [
+	  	{ "name": "clk",     "wave": "p...." },
+	  	{ "name": "Data",    "wave": "x345x",  "data": ["head", "body", "tail"] },
+	  	{ "name": "Request", "wave": "01..0" }
 	  	],
-	  	config: { hscale: 3 }
+	  	"config": { "hscale": 3 }
 	}
 
 Head, foot, tock, text
@@ -163,19 +163,19 @@ Head, foot, tock, text
 
 .. wavedrom::
 
-	{signal: [
-	  	{name:'clk',         wave: 'p....' },
-	  	{name:'Data',        wave: 'x345x', data: 'a b c' },
-	  	{name:'Request',     wave: '01..0' }
+	{"signal": [
+	  	{"name":"clk",         "wave": "p...." },
+	  	{"name":"Data",        "wave": "x345x", "data": "a b c" },
+	  	{"name":"Request",     "wave": "01..0" }
 	],
-	head:{
-		text:'WaveDrom example',
-	   	tick:0,
+	"head":{
+		"text":"WaveDrom example",
+	   	"tick":0
 	},
-	foot:{
-		text:'Figure 100',
-		tock:9
-	},
+	"foot":{
+		"text":"Figure 100",
+		"tock":9
+	}
 	}
 
 H1, h2, h3, h4, h5, h6, muted, warning, error, info, success
@@ -183,33 +183,33 @@ H1, h2, h3, h4, h5, h6, muted, warning, error, info, success
 
 .. wavedrom::
 
-	{signal: [
-	  	{name:'clk', wave: 'p.....PPPPp....' },
-	  	{name:'dat', wave: 'x....2345x.....', data: 'a b c d' },
-	  	{name:'req', wave: '0....1...0.....' }
+	{"signal": [
+	  	{"name":"clk", "wave": "p.....PPPPp...." },
+	  	{"name":"dat", "wave": "x....2345x.....", "data": "a b c d" },
+	  	{"name":"req", "wave": "0....1...0....." }
 	],
-	head: {text:
-	  	['tspan',
-	  	  	['tspan', {class:'error h1'}, 'error '],
-	  	  	['tspan', {class:'warning h2'}, 'warning '],
-	  	  	['tspan', {class:'info h3'}, 'info '],
-	  	  	['tspan', {class:'success h4'}, 'success '],
-	  	  	['tspan', {class:'muted h5'}, 'muted '],
-	  	  	['tspan', {class:'h6'}, 'h6 '],
-	  	  	'default ',
-	  	  	['tspan', {fill:'pink', 'font-weight':'bold', 'font-style':'italic'}, 'pink-bold-italic']
+	"head": {"text":
+	  	["tspan",
+	  	  	["tspan", {"class":"error h1"}, "error "],
+	  	  	["tspan", {"class":"warning h2"}, "warning "],
+	  	  	["tspan", {"class":"info h3"}, "info "],
+	  	  	["tspan", {"class":"success h4"}, "success "],
+	  	  	["tspan", {"class":"muted h5"}, "muted "],
+	  	  	["tspan", {"class":"h6"}, "h6 "],
+	  	  	"default ",
+	  	  	["tspan", {"fill":"pink", "font-weight":"bold", "font-style":"italic"}, "pink-bold-italic"]
 	  	]
 	},
-	foot: {text:
-	  	['tspan', 'E=mc',
-	  	  	['tspan', {dy:'-5'}, '2'],
-	  	  	['tspan', {dy: '5'}, '. '],
-	  	  	['tspan', {'font-size':'25'}, 'B '],
-	  	  	['tspan', {'text-decoration':'overline'},'over '],
-	  	  	['tspan', {'text-decoration':'underline'},'under '],
-	  	  	['tspan', {'baseline-shift':'sub'}, 'sub '],
-	  	  	['tspan', {'baseline-shift':'super'}, 'super ']
-	  	],tock:-5
+	"foot": {"text":
+	  	["tspan", "E=mc",
+	  	  	["tspan", {"dy":"-5"}, "2"],
+	  	  	["tspan", {"dy": "5"}, ". "],
+	  	  	["tspan", {"font-size":"25"}, "B "],
+	  	  	["tspan", {"text-decoration":"overline"},"over "],
+	  	  	["tspan", {"text-decoration":"underline"},"under "],
+	  	  	["tspan", {"baseline-shift":"sub"}, "sub "],
+	  	  	["tspan", {"baseline-shift":"super"}, "super "]
+	  	],"tock":-5
 	}
 	}
 
@@ -222,16 +222,16 @@ Splines
 
 .. wavedrom::
 
-	{ signal: [
-		{ name: 'A', wave: '01........0....',  node: '.a........j' },
-		{ name: 'B', wave: '0.1.......0.1..',  node: '..b.......i' },
-		{ name: 'C', wave: '0..1....0...1..',  node: '...c....h..' },
-		{ name: 'D', wave: '0...1..0.....1.',  node: '....d..g...' },
-		{ name: 'E', wave: '0....10.......1',  node: '.....ef....' }
+	{ "signal": [
+		{ "name": "A", "wave": "01........0....",  "node": ".a........j" },
+		{ "name": "B", "wave": "0.1.......0.1..",  "node": "..b.......i" },
+		{ "name": "C", "wave": "0..1....0...1..",  "node": "...c....h.." },
+		{ "name": "D", "wave": "0...1..0.....1.",  "node": "....d..g..." },
+		{ "name": "E", "wave": "0....10.......1",  "node": ".....ef...." }
 		],
-		edge: [
-			'a~b t1', 'c-~a t2', 'c-~>d time 3', 'd~-e',
-			'e~>f', 'f->g', 'g-~>h', 'h~>i some text', 'h~->j'
+		"edge": [
+			"a~b t1", "c-~a t2", "c-~>d time 3", "d~-e",
+			"e~>f", "f->g", "g-~>h", "h~>i some text", "h~->j"
 		]
 	}
 
@@ -240,43 +240,54 @@ Sharp lines
 
 .. wavedrom::
 
-	{ signal: [
-		{ name: 'A', wave: '01..0..',  node: '.a..e..' },
-		{ name: 'B', wave: '0.1..0.',  node: '..b..d.', phase:0.5 },
-		{ name: 'C', wave: '0..1..0',  node: '...c..f' },
-		{                              node: '...g..h' }
+	{ "signal": [
+		{ "name": "A", "wave": "01..0..",  "node": ".a..e.." },
+		{ "name": "B", "wave": "0.1..0.",  "node": "..b..d.", "phase":0.5 },
+		{ "name": "C", "wave": "0..1..0",  "node": "...c..f" },
+		{                              "node": "...g..h" }
 	],
-	edge: [
-		'b-|a t1', 'a-|c t2', 'b-|-c t3', 'c-|->e t4', 'e-|>f more text',
-		'e|->d t6', 'c-g', 'f-h', 'g<->h 3 ms'
+	"edge": [
+		"b-|a t1", "a-|c t2", "b-|-c t3", "c-|->e t4", "e-|>f more text",
+		"e|->d t6", "c-g", "f-h", "g<->h 3 ms"
 	]}
 	
 =================
 Step 9. Some code
 =================
 
-.. wavedrom::
+.. ifconfig:: wavedrom_html_jsinline
 
-	(function (bits, ticks) {
-		var i, t, gray, state, data = [], arr = [];
-		for (i = 0; i < bits; i++) {
-			arr.push({name: i + '', wave: ''});
-			state = 1;
-			for (t = 0; t < ticks; t++) {
-				data.push(t + '');
-				gray = (((t >> 1) ^ t) >> i) & 1;
-				arr[i].wave += (gray === state) ? '.' : gray + '';
-				state = gray;
-			}
-		}
-		arr.unshift('gray');
-		return {signal: [
-			{name: 'bin', wave: '='.repeat(ticks), data: data}, arr
-		]};
-	})(5, 16)
+    .. wavedrom::
 
-=================
-Step10. From file
-=================
+        (function (bits, ticks) {
+            var i, t, gray, state, data = [], arr = [];
+            for (i = 0; i < bits; i++) {
+                arr.push({"name": i + '', "wave": ''});
+                state = 1;
+                for (t = 0; t < ticks; t++) {
+                    data.push(t + '');
+                    gray = (((t >> 1) ^ t) >> i) & 1;
+                    arr[i].wave += (gray === state) ? '.' : gray + '';
+                    state = gray;
+                }
+            }
+            arr.unshift('gray');
+            return {"signal": [
+                {"name": 'bin', "wave": '='.repeat(ticks), "data": data}, arr
+            ]};
+        })(5, 16)
+
+==================
+Step 10. From file
+==================
 
 .. wavedrom:: example.json
+
+===============
+Step 11. Figure
+===============
+
+.. wavedrom:: example.json
+	:caption: Figure caption
+	:name: examplefig
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==1.1.3
+Sphinx>=1.8
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-Sphinx>=1.8
-sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/bavovanachte/sphinx-wavedrom'
 
-requires = ['Sphinx>=1.8']
+requires = ['Sphinx>=1.8',
+            'wavedrom>=0.1',
+            'cairosvg>=2;python_version>="3.3"',
+            'xcffib;python_version>="3.3"']
 
 setup(
     name='sphinxcontrib-wavedrom',
@@ -12,8 +15,8 @@ setup(
     },
     url='https://github.com/bavovanachte/sphinx-wavedrom',
     license='MIT license',
-    author='Bavo Van Achte',
-    author_email='bavo.van.achte@gmail.com',
+    author='Bavo Van Achte, Stefan Wallentowitz',
+    author_email='bavo.van.achte@gmail.com, stefan@wallentowitz.de',
     description='A sphinx extension that allows generating wavedrom diagrams based on their textual representation',
     long_description=open("README.rst").read(),
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,11 @@ requires = ['Sphinx>=1.8']
 
 setup(
     name='sphinxcontrib-wavedrom',
-    version='1.3.1',
+    use_scm_version={
+        "relative_to": __file__,
+        "write_to": "sphinxcontrib/version.py",
+    },
     url='https://github.com/bavovanachte/sphinx-wavedrom',
-    download_url='https://github.com/bavovanachte/sphinx-wavedrom/tarball/1.3.0',
     license='MIT license',
     author='Bavo Van Achte',
     author_email='bavo.van.achte@gmail.com',
@@ -20,6 +22,9 @@ setup(
     packages=find_packages(exclude=['example']),
     include_package_data=True,
     install_requires=requires,
+    setup_requires=[
+        'setuptools_scm',
+    ],
     namespace_packages=['sphinxcontrib'],
     keywords = ['sphinx', 'wavedrom', 'documentation'],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/bavovanachte/sphinx-wavedrom'
 
-requires = ['Sphinx>=0.6']
+requires = ['Sphinx>=1.8']
 
 setup(
     name='sphinxcontrib-wavedrom',

--- a/sphinxcontrib/wavedrom.py
+++ b/sphinxcontrib/wavedrom.py
@@ -95,6 +95,13 @@ class WavedromDirective(Image, SphinxDirective):
         node = wavedromnode()
 
         node['code'] = code
+        wd_node = node # point to the actual wavedrom node
+
+        # A caption option turns this image into a Figure
+        caption = self.options.get('caption')
+        if caption:
+            node = figure_wrapper(self, wd_node, caption)
+            self.add_name(node)
 
         # Run image directive processing for the options, supply dummy argument, otherwise will fail.
         # We don't actually replace this node by the image_node and will also not make it a child,
@@ -102,13 +109,7 @@ class WavedromDirective(Image, SphinxDirective):
         # want to generate any files in the user sources. Store the image_node private to this node
         # and not in the docutils tree and use it later. Revisit this when the situation changes.
         self.arguments = ["dummy"]
-        (node['image_node'],) = Image.run(self)
-
-        # A caption option turns this image into a Figure
-        caption = self.options.get('caption')
-        if caption:
-            node = figure_wrapper(self, node, caption)
-            pass
+        (wd_node['image_node'],) = Image.run(self)
 
         return [node]
 

--- a/sphinxcontrib/wavedrom.py
+++ b/sphinxcontrib/wavedrom.py
@@ -1,23 +1,27 @@
-"""
-This sphinx extension allows the user to include wavedrom waveform diagrams
-in its documentation, by just using the textual description, rather than
-generating and including static images.
+# We need this for older python versions, otherwise it will not use the wavedrom module
+from __future__ import absolute_import
 
-At the moment, the extension doesn't generate static images itself, but
-relies on the js scripts provided by wavedrom to generate them in the browser.
-
-By default, the script will use the js hosted on the wavedrom servers.
-This is the easiest setup, but relies on an active internet connection and a
-stable hosting on wavedrom's side. In the near future, I aim to add the possibility
-to use a local version of the js scripting, to allow for offline reading.
-"""
+import json
+import os
+from os import path
+from uuid import uuid4
 
 from docutils import nodes
+from docutils.parsers.rst import directives
+from docutils.parsers.rst.directives.images import Image
+from sphinx.errors import SphinxError
+from sphinx.ext.graphviz import figure_wrapper
 from sphinx.util import copy_static_entry
-from os import path
 from sphinx.locale import __
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.i18n import search_image_for_language
+from wavedrom import WaveDrom
+
+# This exception was not always available..
+try:
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
 
 ONLINE_SKIN_JS = "http://wavedrom.com/skins/default.js"
 ONLINE_WAVEDROM_JS = "http://wavedrom.com/WaveDrom.js"
@@ -31,29 +35,32 @@ WAVEDROM_HTML = """
 """
 
 
-class WavedromDirective(SphinxDirective):
+class wavedromnode(nodes.General, nodes.Inline, nodes.Element):
     """
-    Directive to declare items and their traceability relationships.
-    Syntax::
-
-      .. wavedrom::
-
-         [wavedrom_description]
-
-    This directive will trigger the generation of a "raw" docutils node.
-    The raw html content will be the same as the one passed on to the directive,
-    but surrounded by some HTML tags that allow rendering of the image through javascript.
-
+    Special node for wavedrom figures. It is not used for inline javascript.
     """
-    # Setting has_content to true marks that this directive has content (stored in self.content)
+    pass
+
+
+class WavedromDirective(Image, SphinxDirective):
+    """
+    Directive to insert a wavedrom image.
+
+    It derives from image, but is plain html when inline javascript is used.
+    """
     has_content = True
 
     required_arguments = 0
     optional_arguments = 1
     final_argument_whitespace = False
 
+    option_spec = Image.option_spec.copy()
+    option_spec['caption'] = directives.unchanged
+    has_content = True
+
     def run(self):
         if self.arguments:
+            # Read code from file
             document = self.state.document
             if self.content:
                 return [document.reporter.warning(
@@ -70,24 +77,143 @@ class WavedromDirective(SphinxDirective):
                     __('External wavedrom json file %r not found or reading '
                        'it failed') % filename, line=self.lineno)]
         else:
+            # Read code from given content
             code = "\n".join(self.content)
             if not code.strip():
                 return [self.state_machine.reporter.warning(
                     __('Ignoring "wavedrom" directive without content.'),
                     line=self.lineno)]
 
-        text = WAVEDROM_HTML.format(content=code)
-        content = nodes.raw(text=text, format='html')
-        return [content]
+        # For html output with inline JS enabled, just return plain HTML
+        if (self.env.app.builder.name in ('html', 'dirhtml', 'singlehtml')
+            and self.config.wavedrom_html_jsinline):
+            text = WAVEDROM_HTML.format(content=code)
+            content = nodes.raw(text=text, format='html')
+            return [content]
+
+        # Store code in a special docutils node and pick up at rendering
+        node = wavedromnode()
+
+        node['code'] = code
+
+        # Run image directive processing for the options, supply dummy argument, otherwise will fail.
+        # We don't actually replace this node by the image_node and will also not make it a child,
+        # because intermediate steps, like converters, depend on the file being in sources. We don't
+        # want to generate any files in the user sources. Store the image_node private to this node
+        # and not in the docutils tree and use it later. Revisit this when the situation changes.
+        self.arguments = ["dummy"]
+        (node['image_node'],) = Image.run(self)
+
+        # A caption option turns this image into a Figure
+        caption = self.options.get('caption')
+        if caption:
+            node = figure_wrapper(self, node, caption)
+            pass
+
+        return [node]
+
+
+def determine_format(supported):
+    """
+    Determine the proper format to render
+    :param supported: list of formats that the builder supports
+    :return: Preferred format
+    """
+    order = ['image/svg+xml', 'application/pdf', 'image/png']
+    for format in order:
+        if format in supported:
+            return format
+    return None
+
+
+def render_wavedrom(self, node, outpath, bname, format):
+    """
+    Render a wavedrom image
+    """
+
+    # Try to convert node, raise error with code on failure
+    try:
+        svgout = WaveDrom().renderWaveForm(0, json.loads(node['code']))
+    except JSONDecodeError as e:
+        raise SphinxError("Cannot render the following json code: \n{} \n\nError: {}".format(node['code'], e))
+
+    if not os.path.exists(outpath):
+        os.makedirs(outpath)
+
+    # SVG can be directly written and is supported on all versions
+    if format == 'image/svg+xml':
+        fname = "{}.{}".format(bname, "svg")
+        fpath = os.path.join(outpath, fname)
+        svgout.saveas(fpath)
+        return fname
+
+    # It gets a bit ugly, if the output does not support svg. We use cairosvg, because it is the easiest
+    # to use (no dependency on installed programs). But it only works for Python 3.
+    try:
+        import cairosvg
+    except:
+        raise SphinxError(__("Cannot import 'cairosvg'. In Python 2 wavedrom figures other than svg are "
+                             "not supported, in Python 3 ensure 'cairosvg' is installed."))
+
+    if format == 'application/pdf':
+        fname = "{}.{}".format(bname, "pdf")
+        fpath = os.path.join(outpath, fname)
+        cairosvg.svg2pdf(svgout.tostring(), write_to=fpath)
+        return fname
+
+    if format == 'image/png':
+        fname = "{}.{}".format(bname, "png")
+        fpath = os.path.join(outpath, fname)
+        cairosvg.svg2png(svgout.tostring(), write_to=fpath)
+        return fname
+
+    raise SphinxError("No valid wavedrom conversion supplied")
+
+
+def visit_wavedrom(self, node):
+    """
+    Visit the wavedrom node
+    """
+    format = determine_format(self.builder.supported_image_types)
+    if format is None:
+        raise SphinxError(__("Cannot determine a suitable output format"))
+
+    # Create random filename
+    bname = "wavedrom-{}".format(uuid4())
+    outpath = path.join(self.builder.outdir, self.builder.imagedir)
+
+    # Render the wavedrom image
+    imgname = render_wavedrom(self, node, outpath, bname, format)
+
+    # Now we unpack the image node again. The file was created at the build destination,
+    # and we can now use the standard visitor for the image node. We add the image node
+    # as a child and then raise a SkipDepature, which will trigger the builder to visit
+    # children.
+    image_node = node['image_node']
+    image_node['uri'] = os.path.join(self.builder.imgpath, imgname)
+    node.append(image_node)
+
+    raise nodes.SkipDeparture
 
 
 def builder_inited(app):
     """
+    Sets wavedrom_html_jsinline to False for all non-html builders for
+    convenience (use ifconf etc.)
+
     We instruct sphinx to include some javascript files in the output html.
     Depending on the settings provided in the configuration, we take either
     the online files from the wavedrom server, or the locally provided wavedrom
     javascript files
     """
+    if (app.config.wavedrom_html_jsinline and
+        app.builder.name not in ('html', 'dirhtml', 'singlehtml')):
+        app.config.wavedrom_html_jsinline = False
+
+    # Skip for non-html or if javascript is not inlined
+    if not app.env.config.wavedrom_html_jsinline:
+        return
+
     if app.config.offline_skin_js_path is not None:
         app.add_javascript(path.basename(app.config.offline_skin_js_path))
     else:
@@ -97,15 +223,21 @@ def builder_inited(app):
     else:
         app.add_javascript(ONLINE_WAVEDROM_JS)
 
+
 def build_finished(app, exception):
     """
     When the build is finished, we copy the javascript files (if specified)
     to the build directory (the static folder)
     """
+    # Skip for non-html or if javascript is not inlined
+    if not app.env.config.wavedrom_html_jsinline:
+        return
+
     if app.config.offline_skin_js_path is not None:
         copy_static_entry(path.join(app.builder.srcdir, app.config.offline_skin_js_path), path.join(app.builder.outdir, '_static'), app.builder)
     if app.config.offline_wavedrom_js_path is not None:
         copy_static_entry(path.join(app.builder.srcdir, app.config.offline_wavedrom_js_path), path.join(app.builder.outdir, '_static'), app.builder)
+
 
 def doctree_resolved(app, doctree, fromdocname):
     """
@@ -113,6 +245,10 @@ def doctree_resolved(app, doctree, fromdocname):
     raw html element for running the command for processing the wavedrom
     diagrams at the onload event.
     """
+    # Skip for non-html or if javascript is not inlined
+    if not app.env.config.wavedrom_html_jsinline:
+        return
+
     text = """
     <script type="text/javascript">
         function init() {
@@ -121,14 +257,22 @@ def doctree_resolved(app, doctree, fromdocname):
         window.onload = init;
     </script>"""
     doctree.append(nodes.raw(text=text, format='html'))
-# -----------------------------------------------------------------------------
-# Extension setup
+
 
 def setup(app):
+    """
+    Setup the extension
+    """
     app.add_config_value('offline_skin_js_path', None, 'html')
     app.add_config_value('offline_wavedrom_js_path', None, 'html')
+    app.add_config_value('wavedrom_html_jsinline', True, 'html')
     app.add_directive('wavedrom', WavedromDirective)
     app.connect('build-finished', build_finished)
     app.connect('builder-inited', builder_inited)
     app.connect('doctree-resolved', doctree_resolved)
+
+    app.add_node(wavedromnode,
+                 html = (visit_wavedrom, None),
+                 latex = (visit_wavedrom, None),
+                 )
 


### PR DESCRIPTION
Hi,

This adds the feature to read the json code from a file (fixes #7), and it also adds the capability to generate files instead of inline javascript (fixes #6). It has one minor caveat, that `latexpdf` image rendering only works with Python 3. See the respective commit for the reasoning.

I also did some travis housekeeping and setuptools housekeeping. Most importantly, the versioning is not done implicitly via tags in git. So, I propose to tag after this merge as `2.0` and publish that via twine (the legacy way of automatically deploying via travis seems broken).

I hope you like it!

Cheers,
Stefan