### PR TITLE
Support all data types

### DIFF
--- a/example/source/index.rst
+++ b/example/source/index.rst
@@ -291,3 +291,18 @@ Step 11. Figure
 	:caption: Figure caption
 	:name: examplefig
 
+========
+Register
+========
+
+.. wavedrom::
+
+  { "reg": [
+    { "name": "IPO",   "bits": 8, "attr": "RO" },
+    {                  "bits": 7 },
+    { "name": "BRK",   "bits": 5, "attr": "RW", "type": 1 },
+    { "name": "CPK",   "bits": 1 },
+    { "name": "Clear", "bits": 3 },
+    { "bits": 8 }
+  ]}
+

--- a/sphinxcontrib/wavedrom.py
+++ b/sphinxcontrib/wavedrom.py
@@ -15,7 +15,7 @@ from sphinx.util import copy_static_entry
 from sphinx.locale import __
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.i18n import search_image_for_language
-from wavedrom import WaveDrom
+from wavedrom import render
 
 # This exception was not always available..
 try:
@@ -134,7 +134,7 @@ def render_wavedrom(self, node, outpath, bname, format):
 
     # Try to convert node, raise error with code on failure
     try:
-        svgout = WaveDrom().renderWaveForm(0, json.loads(node['code']))
+        svgout = render(node["code"])
     except JSONDecodeError as e:
         raise SphinxError("Cannot render the following json code: \n{} \n\nError: {}".format(node['code'], e))
 


### PR DESCRIPTION
This is an example of how to address issue #11.  Using wavedrom.render() probably merits moving the setup.py requires line forward as well.

This along with wavedrom=1.9.0rc1 allows me to build the example doc for both html and latexpdf targets with WAVEDROM_HTML_NOJSINLINE=1.