### PR TITLE
Update version to release candidate with fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 project_url = 'https://github.com/bavovanachte/sphinx-wavedrom'
 
 requires = ['Sphinx>=1.8',
-            'wavedrom>=0.1',
+            'wavedrom>=1.9.0rc1',
             'cairosvg>=2;python_version>="3.3"',
             'xcffib;python_version>="3.3"']
 


### PR DESCRIPTION
Was much easier actually. The release candidate fixed it already, but it doesn't show up as latest version. I can look into fixing it in the 1.8.0-post release cycle, but probably this is a motiviation to get 1.9.0 done asap.