### PR TITLE
Move default URI to https

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Sphinx wavedrom extension
 
 A sphinx extension that allows including wavedrom diagrams by using its text-based representation
 
-Wavedrom online editor and tutorial: http://wavedrom.com/
+Wavedrom online editor and tutorial: https://wavedrom.com/
 
 .. image:: https://travis-ci.org/bavovanachte/sphinx-wavedrom.svg?branch=master
 	:target: https://travis-ci.org/bavovanachte/sphinx-wavedrom
@@ -129,8 +129,8 @@ conf.py:
 
 If offline mode is desired, the following configuration parameters need to be provided:
 
-- ``offline_skin_js_path`` : the path to the skin javascript file (the url to the online version is "http://wavedrom.com/skins/default.js")
-- ``offline_wavedrom_js_path`` : the path to the wavedrom javascript file (the url to the online version is "http://wavedrom.com/WaveDrom.js")
+- ``offline_skin_js_path`` : the path to the skin javascript file (the url to the online version is "https://wavedrom.com/skins/default.js")
+- ``offline_wavedrom_js_path`` : the path to the wavedrom javascript file (the url to the online version is "https://wavedrom.com/WaveDrom.js")
 
 The paths given for these configurations need to be relative to the configuration directory (the directory that contains conf.py)
 

--- a/example/source/index.rst
+++ b/example/source/index.rst
@@ -20,7 +20,7 @@ The content for this example documentation for the wavedrom sphinx extension was
 entirety borrowed from the `Wavedrom tutorial`_ itself. This is partly because of a lack of inspiration
 and partly to show the behaviour of this plugin matches the images generated on the wavedrom website.
 
-.. _Wavedrom tutorial: http://wavedrom.com/tutorial.html
+.. _Wavedrom tutorial: https://wavedrom.com/tutorial.html
 
 
 ==================

--- a/sphinxcontrib/wavedrom.py
+++ b/sphinxcontrib/wavedrom.py
@@ -188,7 +188,7 @@ def setup(app):
     """
     app.add_config_value('offline_skin_js_path', None, 'html')
     app.add_config_value('offline_wavedrom_js_path', None, 'html')
-    app.add_config_value('online_wavedrom_js_url', "http://wavedrom.com", 'html')
+    app.add_config_value('online_wavedrom_js_url', "https://wavedrom.com", 'html')
     app.add_config_value('wavedrom_html_jsinline', True, 'html')
     app.add_config_value('wavedrom_cli', "npx wavedrom-cli", 'html')
     app.add_config_value('render_using_wavedrompy', False, 'html')


### PR DESCRIPTION
Most targets will probably use https, which leads to an issue when mixing with http content from wavedrom. Anyhow, wavedrom also serves as https. Hence switch over to https for the default.