### PR TITLE
Fix removed ENOENT of sphinx.util.osutil in sphinx 4

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8]
-        sphinx: [1.*, 2.*, 3.*]
+        sphinx: [1.*, 2.*, 3.*, 4.*]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8]
-        sphinx: [ 1.*, 2.*, 3.*]
+        sphinx: [ 1.*, 2.*, 3.*, 4.*]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/sphinxcontrib/wavedrom_render_image.py
+++ b/sphinxcontrib/wavedrom_render_image.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import cairosvg
 from wavedrom import render
 from sphinx.errors import SphinxError
+import errno
 
 # This exception was not always available..
 try:
@@ -13,10 +14,9 @@ try:
 except ImportError:
     JSONDecodeError = ValueError
 
-from sphinx.util.osutil import (
-    ensuredir,
-    ENOENT,
-)
+from sphinx.util.osutil import ensuredir
+
+ENOENT = getattr(errno, 'ENOENT', 0)
 
 def determine_format(supported):
     """


### PR DESCRIPTION
This package is not compatible with the latest version of sphinx.

ENOENT was removed in sphinx 4.