### PR TITLE
Update README links to wavedrom.min.js

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,14 +123,14 @@ conf.py:
 - ``online_wavedrom_js_url`` : the url of the server hosting the javascript files. The plugin will look for 2 files:
 
 	+ {online_wavedrom_js_url}/skins/default.js
-	+ {online_wavedrom_js_url}/wavedrom.js
+	+ {online_wavedrom_js_url}/wavedrom.min.js
 
 **Warning**: A full URI is needed when configuring. "http://www.google.com" will work but "www.google.com" won't.
 
 If offline mode is desired, the following configuration parameters need to be provided:
 
 - ``offline_skin_js_path`` : the path to the skin javascript file (the url to the online version is "https://wavedrom.com/skins/default.js")
-- ``offline_wavedrom_js_path`` : the path to the wavedrom javascript file (the url to the online version is "https://wavedrom.com/WaveDrom.js")
+- ``offline_wavedrom_js_path`` : the path to the wavedrom javascript file (the url to the online version is "https://wavedrom.com/wavedrom.min.js")
 
 The paths given for these configurations need to be relative to the configuration directory (the directory that contains conf.py)
 


### PR DESCRIPTION
The correct file name for `online_wavedrom_js_url` is [wavedrom.min.js](https://github.com/bavovanachte/sphinx-wavedrom/blob/26ac058c73a25aff3ee9cd0e64c9c4b4c260c907/sphinxcontrib/wavedrom.py#L18) and the correct online version is `https://wavedrom.com/wavedrom.min.js`.