### PR TITLE
ci/testing: disable fail-fast

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,7 @@ jobs:
   html:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python: [3.6, 3.7, 3.8]
         sphinx: [1.*, 2.*, 3.*, 4.*]
@@ -39,6 +40,7 @@ jobs:
   pdf-with-wavedromcli:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python: [3.6, 3.7, 3.8]
         sphinx: [ 1.*, 2.*, 3.*, 4.*]


### PR DESCRIPTION
Currently, if one of the jobs fails, the whole matrix is cancelled. This PR disables fail-fast, to allow jobs to continue despite one of them failing.