### PR TITLE
ci/testing: test on Python 3.9 and 3.10 as well

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         sphinx: [1.*, 2.*, 3.*, 4.*]
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         sphinx: [ 1.*, 2.*, 3.*, 4.*]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,7 @@ jobs:
   html:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python: [3.6, 3.7, 3.8]
         sphinx: [1.*, 2.*, 3.*, 4.*]
@@ -39,6 +40,7 @@ jobs:
   pdf-with-wavedromcli:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python: [3.6, 3.7, 3.8]
         sphinx: [ 1.*, 2.*, 3.*, 4.*]


### PR DESCRIPTION
This PR updates the list of Python versions tested in CI, to add 3.9 and 3.10.