### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description='A sphinx extension that allows generating wavedrom diagrams based on their textual representation',
     long_description=open("README.rst").read(),
     zip_safe=False,
-    classifiers=[],
+    classifiers=['Framework :: Sphinx :: Extension'],
     platforms='any',
     packages=find_packages(exclude=['example']),
     include_package_data=True,


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).