### PR TITLE
Improve error message in rendering

### DIFF
--- a/sphinxcontrib/wavedrom_render_image.py
+++ b/sphinxcontrib/wavedrom_render_image.py
@@ -38,8 +38,12 @@ def render_wavedrom_py(node, outpath, bname, image_format):
     # Try to convert node, raise error with code on failure
     try:
         svgout = render(node["code"])
-    except JSONDecodeError as exception:
-        raise SphinxError("Cannot render the following json code: \n{} \n\nError: {}".format(node['code'], exception))
+    except Exception:
+        print(
+            "Cannot render the following json code: \n{} \n\n".format(
+                node['code']),
+            file=sys.stderr)
+        raise
 
     if not os.path.exists(outpath):
         os.makedirs(outpath)


### PR DESCRIPTION
If an edge does not exist, this leads to the exception below, which makes it hard to track down without the corresponding .json code.

With this change, the .json is dumped for all rendering failure exceptions.

Output is now:

```
Cannot render the following json code:
{ "signal": [
[deleted]

Exception occurred:
  File .../site-packages/wavedrom/waveform.py, line 590, in render_arcs
    frm = AttrDict(Events[Edge.frm])
                   ~~~~~~^^^^^^^^^^
KeyError: 'd'
```